### PR TITLE
Fix typo in comment of proto_conn_create

### DIFF
--- a/proto/proto_conn.c
+++ b/proto/proto_conn.c
@@ -190,7 +190,7 @@ dropconn(struct conn_state * C)
  *     callback_dead, cookie):
  * Create a connection with one end at ${s} and the other end connecting to
  * the target addresses ${sas}.  If ${decr} is 0, encrypt the outgoing data;
- * if ${decr} is nonzero, decrypt the outgoing data.  If ${nofps} is non-zero,
+ * if ${decr} is nonzero, decrypt the incoming data.  If ${nofps} is non-zero,
  * don't use perfect forward secrecy.  If ${requirefps} is non-zero, drop
  * the connection if the other end tries to disable perfect forward secrecy.
  * Enable transport layer keep-alives (if applicable) on both sockets if and


### PR DESCRIPTION
The wording in the comment now matches the wording of the comment
of dispatch_accept.