### PR TITLE
Compatibility with /dev/stderr and su and linux

### DIFF
--- a/libcperciva/POSIX/posix-cflags.sh
+++ b/libcperciva/POSIX/posix-cflags.sh
@@ -1,10 +1,10 @@
 # Should be sourced by `command -p sh posix-cflags.sh` from within a Makefile
 if ! ${CC} -D_POSIX_C_SOURCE=200809L posix-msg_nosignal.c 2>/dev/null; then
 	printf %s "-DPOSIXFAIL_MSG_NOSIGNAL "
-	echo "WARNING: POSIX violation: <sys/socket.h> not defining MSG_NOSIGNAL" >/dev/stderr
+	echo "WARNING: POSIX violation: <sys/socket.h> not defining MSG_NOSIGNAL" 1>&2
 fi
 if ! ${CC} -D_POSIX_C_SOURCE=200809L posix-clock_realtime.c 2>/dev/null; then
 	printf %s "-DPOSIXFAIL_CLOCK_REALTIME"
-	echo "WARNING: POSIX violation: <time.h> not defining CLOCK_REALTIME" >/dev/stderr
+	echo "WARNING: POSIX violation: <time.h> not defining CLOCK_REALTIME" 1>&2
 fi
 rm -f a.out

--- a/libcperciva/POSIX/posix-l.sh
+++ b/libcperciva/POSIX/posix-l.sh
@@ -8,7 +8,7 @@ for LIB in rt xnet; do
 		printf "%s" "-l${LIB}";
 		FIRST=NO;
 	else
-		echo "WARNING: POSIX violation: make's CC doesn't understand -l${LIB}" >/dev/stderr
+		echo "WARNING: POSIX violation: make's CC doesn't understand -l${LIB}" 1>&2
 	fi
 	rm -f a.out
 done


### PR DESCRIPTION
This was a fun one!  TL;DR: my OS doesn't update the ownership of /dev/stderr
when su'ing into a new account, so attempting to redirect to /dev/stderr fails
with a "permission denied".

My main user (the one running X11) is gperciva.  I opened an xterm, did
$ su td
    (for "tarsnap development"), and then
td@gin: ~/src/spiped/libcperciva/POSIX (stderr-compatibility)
$ ls -lL /dev/stderr
crw--w---- 1 gperciva tty 136, 2 Dec 20 11:43 /dev/stderr

According to at least one comment on an internet forum (what could go
wrong?!), the shell is *supposed* to treat /dev/stderr as a special case (and
internally use 1>&2), but if that file exists, then it attempts to write
directly to it.  Which fails, since ownership of /dev/stderr is not updated
when using su.

Long description here:
http://unix.stackexchange.com/questions/38538/bash-dev-stderr-permission-denied
(I'm using dash instead of bash, but the problem is the same)