### PR TITLE
Add proto_conn_shutdown() and error path to spipe

### DIFF
--- a/proto/proto_conn.h
+++ b/proto/proto_conn.h
@@ -17,9 +17,16 @@ struct sock_addr;
  * only if ${nokeepalive} is zero.  Drop the connection if the handshake or
  * connecting to the target takes more than ${timeo} seconds.  When the
  * connection is dropped, invoke ${callback_dead}(${cookie}).  Free ${sas}
- * once it is no longer needed.
+ * once it is no longer needed.  Returns a cookie which can be passed to
+ * proto_conn_shutdown.
  */
-int proto_conn_create(int, struct sock_addr **, int, int, int, int,
+void * proto_conn_create(int, struct sock_addr **, int, int, int, int,
     const struct proto_secret *, double, int (*)(void *), void *);
+
+/**
+ * proto_conn_shutdown(conn_cookie):
+ * Stops and frees memory associated with the ${conn_cookie).
+ */
+void proto_conn_shutdown(void *);
 
 #endif /* !_CONN_H_ */

--- a/spipe/main.c
+++ b/spipe/main.c
@@ -62,6 +62,7 @@ main(int argc, char * argv[])
 	struct proto_secret * K;
 	const char * ch;
 	int s[2];
+	void * conn_cookie = NULL;
 
 	WARNP_INIT;
 
@@ -162,8 +163,8 @@ main(int argc, char * argv[])
 	}
 
 	/* Set up a connection. */
-	if (proto_conn_create(s[1], sas_t, 0, opt_f, opt_g, opt_j, K, opt_o,
-	    callback_conndied, NULL)) {
+	if ((conn_cookie = proto_conn_create(s[1], sas_t, 0, opt_f, opt_g,
+	    opt_j, K, opt_o, callback_conndied, NULL)) == NULL) {
 		warnp("Could not set up connection");
 		goto err3;
 	}
@@ -171,7 +172,7 @@ main(int argc, char * argv[])
 	/* Push bits from stdin into the socket. */
 	if (pushbits(STDIN_FILENO, s[0]) || pushbits(s[0], STDOUT_FILENO)) {
 		warnp("Could not push bits");
-		exit(1);
+		goto err4;
 	}
 
 	/* Loop until we die. */
@@ -184,6 +185,8 @@ main(int argc, char * argv[])
 
 	/* NOTREACHED */
 
+err4:
+	proto_conn_shutdown(conn_cookie);
 err3:
 	events_shutdown();
 err2:

--- a/spipe/main.c
+++ b/spipe/main.c
@@ -135,17 +135,17 @@ main(int argc, char * argv[])
 	/* Resolve target address. */
 	if ((sas_t = sock_resolve(opt_t)) == NULL) {
 		warnp("Error resolving socket address: %s", opt_t);
-		exit(1);
+		goto err0;
 	}
 	if (sas_t[0] == NULL) {
 		warn0("No addresses found for %s", opt_t);
-		exit(1);
+		goto err1;
 	}
 
 	/* Load the keying data. */
 	if ((K = proto_crypt_secret(opt_k)) == NULL) {
 		warnp("Error reading shared secret");
-		exit(1);
+		goto err1;
 	}
 
 	/*
@@ -158,14 +158,14 @@ main(int argc, char * argv[])
 	 */
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, s)) {
 		warnp("socketpair");
-		exit(1);
+		goto err2;
 	}
 
 	/* Set up a connection. */
 	if (proto_conn_create(s[1], sas_t, 0, opt_f, opt_g, opt_j, K, opt_o,
 	    callback_conndied, NULL)) {
 		warnp("Could not set up connection");
-		exit(1);
+		goto err3;
 	}
 
 	/* Push bits from stdin into the socket. */
@@ -183,8 +183,14 @@ main(int argc, char * argv[])
 	} while (1);
 
 	/* NOTREACHED */
-	/*
-	 * If we could reach this point, we would free memory, close sockets,
-	 * and otherwise clean up here.
-	 */
+
+err3:
+	events_shutdown();
+err2:
+	free(K);
+err1:
+	sock_addr_freelist(sas_t);
+err0:
+	/* Failure! */
+	exit(1);
 }


### PR DESCRIPTION
The error path only applies to the first half of spipe main.c; cleaning up the
sockets and pthreads is deferred to a later commit.