### PR TITLE
Run spiped only once with -1

### DIFF
--- a/spiped/dispatch.c
+++ b/spiped/dispatch.c
@@ -158,7 +158,7 @@ err0:
  * the addresses ${sas}.  If ${decr} is 0, encrypt the outgoing connections; if
  * ${decr} is non-zero, decrypt the incoming connections.  Don't accept more
  * than ${nconn_max} connections.  If ${nofps} is non-zero, don't use perfect
- * forward secrecy.  If {$requirefps} is non-zero, require that both ends use
+ * forward secrecy.  If ${requirefps} is non-zero, require that both ends use
  * perfect forward secrecy.  Enable transport layer keep-alives (if applicable)
  * if and only if ${nokeepalive} is zero.  Drop connections if the handshake or
  * connecting to the target takes more than ${timeo} seconds.  Returns a

--- a/spiped/dispatch.c
+++ b/spiped/dispatch.c
@@ -22,6 +22,7 @@ struct accept_state {
 	int nofps;
 	int requirefps;
 	int nokeepalive;
+	int * conndone;
 	const struct proto_secret * K;
 	size_t nconn;
 	size_t nconn_max;
@@ -98,6 +99,10 @@ callback_conndied(void * cookie)
 	/* We've lost a connection. */
 	A->nconn -= 1;
 
+	/* If requested to do so, indicate that a connection closed. */
+	if (A->conndone != NULL)
+		*A->conndone = 1;
+
 	/* Maybe accept more connections. */
 	return (doaccept(A));
 }
@@ -151,7 +156,7 @@ err0:
 
 /**
  * dispatch_accept(s, tgt, rtime, sas, decr, nofps, requirefps, nokeepalive, K,
- *     nconn_max, timeo):
+ *     nconn_max, timeo, conndone):
  * Start accepting connections on the socket ${s}.  Connect to the target
  * ${tgt}, re-resolving it every ${rtime} seconds if ${rtime} > 0; on address
  * resolution failure use the most recent successfully obtained addresses, or
@@ -161,13 +166,15 @@ err0:
  * forward secrecy.  If ${requirefps} is non-zero, require that both ends use
  * perfect forward secrecy.  Enable transport layer keep-alives (if applicable)
  * if and only if ${nokeepalive} is zero.  Drop connections if the handshake or
- * connecting to the target takes more than ${timeo} seconds.  Returns a
+ * connecting to the target takes more than ${timeo} seconds.  If ${conndone}
+ * is not NULL, set it to non-zero value when a connection closes.  Returns a
  * cookie which can be passed to dispatch_shutdown.
  */
 void *
 dispatch_accept(int s, const char * tgt, double rtime, struct sock_addr ** sas,
     int decr, int nofps, int requirefps, int nokeepalive,
-    const struct proto_secret * K, size_t nconn_max, double timeo)
+    const struct proto_secret * K, size_t nconn_max, double timeo,
+    int * conndone)
 {
 	struct accept_state * A;
 
@@ -182,6 +189,7 @@ dispatch_accept(int s, const char * tgt, double rtime, struct sock_addr ** sas,
 	A->nofps = nofps;
 	A->requirefps = requirefps;
 	A->nokeepalive = nokeepalive;
+	A->conndone = conndone;
 	A->K = K;
 	A->nconn = 0;
 	A->nconn_max = nconn_max;

--- a/spiped/dispatch.h
+++ b/spiped/dispatch.h
@@ -16,7 +16,7 @@ struct sock_addr;
  * the addresses ${sas}.  If ${decr} is 0, encrypt the outgoing connections; if
  * ${decr} is non-zero, decrypt the incoming connections.  Don't accept more
  * than ${nconn_max} connections.  If ${nofps} is non-zero, don't use perfect
- * forward secrecy.  If {$requirefps} is non-zero, require that both ends use
+ * forward secrecy.  If ${requirefps} is non-zero, require that both ends use
  * perfect forward secrecy.  Enable transport layer keep-alives (if applicable)
  * if and only if ${nokeepalive} is zero.  Drop connections if the handshake or
  * connecting to the target takes more than ${timeo} seconds.  Returns a

--- a/spiped/dispatch.h
+++ b/spiped/dispatch.h
@@ -9,7 +9,7 @@ struct sock_addr;
 
 /**
  * dispatch_accept(s, tgt, rtime, sas, decr, nofps, requirefps, nokeepalive, K,
- *     nconn_max, timeo):
+ *     nconn_max, timeo, conndone):
  * Start accepting connections on the socket ${s}.  Connect to the target
  * ${tgt}, re-resolving it every ${rtime} seconds if ${rtime} > 0; on address
  * resolution failure use the most recent successfully obtained addresses, or
@@ -19,11 +19,12 @@ struct sock_addr;
  * forward secrecy.  If ${requirefps} is non-zero, require that both ends use
  * perfect forward secrecy.  Enable transport layer keep-alives (if applicable)
  * if and only if ${nokeepalive} is zero.  Drop connections if the handshake or
- * connecting to the target takes more than ${timeo} seconds.  Returns a
+ * connecting to the target takes more than ${timeo} seconds.  If ${conndone}
+ * is not NULL, set it to non-zero value when a connection closes.  Returns a
  * cookie which can be passed to dispatch_shutdown.
  */
 void * dispatch_accept(int, const char *, double, struct sock_addr **, int, int,
-    int, int, const struct proto_secret *, size_t, double);
+    int, int, const struct proto_secret *, size_t, double, int *);
 
 /**
  * dispatch_shutdown(dispatch_cookie):

--- a/spiped/spiped.1
+++ b/spiped/spiped.1
@@ -36,6 +36,7 @@ spiped \- secure pipe daemon
 [\-o <connection timeout>]
 [\-p <pidfile>]
 [\-r <rtime> | \-R]
+[-1]
 .br
 .B spiped
 \-v
@@ -115,5 +116,8 @@ Disable target address re-resolution.
 .TP
 .B \-v
 Print version number.
+.TP
+.B \-1
+Exit after a connection closes.  Used for internal testing.
 .SH SEE ALSO
 .BR spipe (1).


### PR DESCRIPTION
I put the man-page documenting of `-1` in a separate commit since you might tell me it should be undocumented.  My vote (which has no value) is that we should still document it, because I won't be able to remember it otherwise, and it's not like anybody can do anything nasty if they know about `-1`.  (and even if they could, they could discover it from the source code anyway).

Since `spipe` can quit with `^D`, I didn't add `-1` there, but you might want me to do so anyway for consistency.