### PR TITLE
libcperciva: initialize sockerr=0

### DIFF
--- a/libcperciva/network/network_connect.c
+++ b/libcperciva/network/network_connect.c
@@ -65,7 +65,7 @@ static int
 callback_connect(void * cookie)
 {
 	struct connect_cookie * C = cookie;
-	int sockerr;
+	int sockerr = 0;
 	socklen_t sockerrlen = sizeof(int);
 
 	/* Stop waiting for the timer callback. */


### PR DESCRIPTION
On FreeBSD 10.2-RELEASE-p9, valgrind-freebsd-3.10.0 claims that with a
successful getsockopt(), &sockerr is not written to, so:

    if (sockerr != 0)

was reading uninitialized memory.