### PR TITLE
Add -c <chmod> support to spiped to set the permissions for created Unix sockets.

### DIFF
--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -328,11 +328,11 @@ sock_listener(const struct sock_addr * sa, mode_t sm)
 	}
 
 	/* Set the Unix socket's permission. */
-	if (sa->ai_family == AF_UNIX && sm != -1) {
-		if (chmod(((struct sockaddr_un *)sa->name)->sun_path, sm)) {
-			warnp("Error calling chmod on Unix socket");
-			goto err1;
-		}
+	if (sa->ai_family == AF_UNIX && sm != -1
+			&& chmod(((struct sockaddr_un *)sa->name)->sun_path, sm)) {
+
+		warnp("Error calling chmod on Unix socket");
+		goto err1;
 	}
 
 	/* Mark the socket as listening. */

--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -327,9 +327,12 @@ sock_listener(const struct sock_addr * sa, mode_t sm)
 		goto err1;
 	}
 
-	/* Set the Unix socket's permission */
+	/* Set the Unix socket's permission. */
 	if (sa->ai_family == AF_UNIX && sm != -1) {
-		chmod(((struct sockaddr_un *)sa->name)->sun_path, sm);
+		if (chmod(((struct sockaddr_un *)sa->name)->sun_path, sm)) {
+			warnp("Error calling chmod on Unix socket");
+			goto err1;
+		}
 	}
 
 	/* Mark the socket as listening. */

--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -300,10 +300,11 @@ err0:
 /**
  * sock_listener(sa):
  * Create a socket, set SO_REUSEADDR, bind it to the socket address ${sa},
- * mark it for listening, and mark it as non-blocking.
+ * set the permission (if not -1), mark it for listening,
+ * and mark it as non-blocking.
  */
 int
-sock_listener(const struct sock_addr * sa)
+sock_listener(const struct sock_addr * sa, mode_t sm)
 {
 	int s;
 	int val = 1;
@@ -324,6 +325,11 @@ sock_listener(const struct sock_addr * sa)
 	if (bind(s, sa->name, sa->namelen)) {
 		warnp("Error binding socket");
 		goto err1;
+	}
+
+	/* Set the Unix socket's permission */
+	if (sa->ai_family == AF_UNIX && sm != -1) {
+		chmod(((struct sockaddr_un *)sa->name)->sun_path, sm);
 	}
 
 	/* Mark the socket as listening. */

--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -298,9 +298,9 @@ err0:
 }
 
 /**
- * sock_listener(sa):
+ * sock_listener(sa, sm):
  * Create a socket, set SO_REUSEADDR, bind it to the socket address ${sa},
- * set the permission (if not -1), mark it for listening,
+ * set the permission to ${sm} (if it's not -1), mark it for listening,
  * and mark it as non-blocking.
  */
 int

--- a/libcperciva/util/sock.h
+++ b/libcperciva/util/sock.h
@@ -1,6 +1,8 @@
 #ifndef _SOCK_H_
 #define _SOCK_H_
 
+#include <sys/types.h>
+
 /**
  * Address strings are of the following forms:
  * /path/to/unix/socket
@@ -21,9 +23,10 @@ struct sock_addr ** sock_resolve(const char *);
 /**
  * sock_listener(sa):
  * Create a socket, set SO_REUSEADDR, bind it to the socket address ${sa},
- * mark it for listening, and mark it as non-blocking.
+ * set the permission (if not -1), mark it for listening,
+ * and mark it as non-blocking.
  */
-int sock_listener(const struct sock_addr *);
+int sock_listener(const struct sock_addr *, mode_t);
 
 /**
  * sock_connect(sas):

--- a/libcperciva/util/sock.h
+++ b/libcperciva/util/sock.h
@@ -21,9 +21,9 @@ struct sock_addr;
 struct sock_addr ** sock_resolve(const char *);
 
 /**
- * sock_listener(sa):
+ * sock_listener(sa, sm):
  * Create a socket, set SO_REUSEADDR, bind it to the socket address ${sa},
- * set the permission (if not -1), mark it for listening,
+ * set the permission to ${sm} (if it's not -1), mark it for listening,
  * and mark it as non-blocking.
  */
 int sock_listener(const struct sock_addr *, mode_t);

--- a/spiped/README
+++ b/spiped/README
@@ -4,8 +4,13 @@ spiped usage
 usage: spiped {-e | -d} -s <source socket> -t <target socket> -k <key file>
     [-DFj] [-f | -g] [-n <max # connections>] [-o <connection timeout>]
     [-p <pidfile>] [-r <rtime> | -R]
+    [-c <source chmod>]
 
 Options:
+    -c <source chmod>
+	The access permissions of the source socket (if it's a Unix socket).
+	For example: -c 777
+    Defaults to the system default of source sockets.
     -e
 	Take unencrypted connections from the source socket and send
 	encrypted connections to the target socket.

--- a/spiped/README
+++ b/spiped/README
@@ -8,8 +8,8 @@ usage: spiped {-e | -d} -s <source socket> -t <target socket> -k <key file>
 
 Options:
     -c <source chmod>
-	The access permissions of the source socket (if it's a Unix socket).
-	For example: -c 777
+    The access permissions of the source socket (if it's a Unix socket).
+    For example: -c 777
     Defaults to the system default of source sockets.
     -e
 	Take unencrypted connections from the source socket and send

--- a/spiped/README
+++ b/spiped/README
@@ -8,9 +8,9 @@ usage: spiped {-e | -d} -s <source socket> -t <target socket> -k <key file>
 
 Options:
     -c <source chmod>
-    The access permissions of the source socket (if it's a Unix socket).
-    For example: -c 777
-    Defaults to the system default of source sockets.
+	The access permissions of the source socket (if it's a Unix socket).
+	For example: -c 777
+	Defaults to the system default of source sockets.
     -e
 	Take unencrypted connections from the source socket and send
 	encrypted connections to the target socket.

--- a/spiped/README
+++ b/spiped/README
@@ -9,7 +9,6 @@ usage: spiped {-e | -d} -s <source socket> -t <target socket> -k <key file>
 Options:
     -c <source chmod>
 	The access permissions of the source socket (if it's a Unix socket).
-	For example: -c 777
 	Defaults to the system default of source sockets.
     -e
 	Take unencrypted connections from the source socket and send

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -25,7 +25,7 @@ usage(void)
 	    "    [-DFj] [-f | -g] [-n <max # connections>] "
 	    "[-o <connection timeout>]\n"
 	    "    [-p <pidfile>] [-r <rtime> | -R] [-1]\n"
-		"    [-c <source chmod>]\n"
+	    "    [-c <source chmod>]\n"
 	    "       spiped -v\n");
 	exit(1);
 }
@@ -88,10 +88,10 @@ main(int argc, char * argv[])
 			if (opt_c != -1)
 				usage();
 
-			// read-in the chmod octal for the source socket
+			/* read-in the chmod octal for the source socket */
 			opt_c = (mode_t)strtol(optarg, NULL, 8);
 
-			// handle invalid user input
+			/* handle invalid user input */
 			if (opt_c < 0 || opt_c > 0777) {
 				warn0("The parameter to -c must be between 000 and 777\n");
 				exit(1);

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -92,8 +92,7 @@ main(int argc, char * argv[])
 			opt_c = (mode_t)strtol(optarg, NULL, 8);
 
 			// handle invalid user input
-			if (opt_c < 0 || opt_c > 0777)
-			{
+			if (opt_c < 0 || opt_c > 0777) {
 				warn0("The parameter to -c must be between 000 and 777\n");
 				exit(1);
 			}

--- a/spiped/spiped.1
+++ b/spiped/spiped.1
@@ -37,10 +37,16 @@ spiped \- secure pipe daemon
 [\-p <pidfile>]
 [\-r <rtime> | \-R]
 [-1]
+[\-c <source chmod>]
 .br
 .B spiped
 \-v
 .SH OPTIONS
+.TP
+.B \-c <source chmod>
+The access permissions of the source socket (if it's a Unix socket).
+For example: -c 777
+Defaults to the system default of source sockets.
 .TP
 .B \-e
 Take unencrypted connections from the source socket and send

--- a/spiped/spiped.1
+++ b/spiped/spiped.1
@@ -45,7 +45,6 @@ spiped \- secure pipe daemon
 .TP
 .B \-c <source chmod>
 The access permissions of the source socket (if it's a Unix socket).
-For example: -c 777
 Defaults to the system default of source sockets.
 .TP
 .B \-e


### PR DESCRIPTION
A justification for this addition: we use spiped at boot time on a number of our servers. And we need the Unix socket spiped creates to be available immediately to other processes. There's no good way to do this on our systems which use the "Upstart" init system (short of creating another processes that waits for spiped to create the socket, then altering the permissions of the socket).

We're already using these modifications in production.