### PR TITLE
spipe: make sure all the I/O has been completed.

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -1,6 +1,7 @@
 #include <sys/socket.h>
 
 #include <inttypes.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -18,11 +19,21 @@
 
 #include "pushbits.h"
 
+static pthread_t	threads[2];
+
 static int
 callback_conndied(void * cookie)
 {
+	unsigned i;
 
 	(void)cookie; /* UNUSED */
+
+	for (i = 0; i < 2; i++)
+		if (!pthread_equal(threads[i], pthread_self()))
+		{
+			pthread_join(threads[i], NULL);
+			threads[i] = pthread_self();
+		}
 
 	/* We're done! */
 	exit(0);
@@ -62,6 +73,7 @@ main(int argc, char * argv[])
 	struct proto_secret * K;
 	const char * ch;
 	int s[2];
+	unsigned i;
 
 	WARNP_INIT;
 
@@ -161,6 +173,9 @@ main(int argc, char * argv[])
 		exit(1);
 	}
 
+	for (i = 0; i < 2; i++)
+		threads[i] = pthread_self();
+
 	/* Set up a connection. */
 	if (proto_conn_create(s[1], sas_t, 0, opt_f, opt_g, opt_j, K, opt_o,
 	    callback_conndied, NULL)) {
@@ -169,7 +184,8 @@ main(int argc, char * argv[])
 	}
 
 	/* Push bits from stdin into the socket. */
-	if (pushbits(STDIN_FILENO, s[0]) || pushbits(s[0], STDOUT_FILENO)) {
+	if (pushbits(STDIN_FILENO, s[0], &threads[0]) ||
+	    pushbits(s[0], STDOUT_FILENO, &threads[1])) {
 		warnp("Could not push bits");
 		exit(1);
 	}

--- a/spipe/pushbits.c
+++ b/spipe/pushbits.c
@@ -72,10 +72,9 @@ workthread(void * cookie)
  * Create a thread which copies data from ${in} to ${out}.
  */
 int
-pushbits(int in, int out)
+pushbits(int in, int out, pthread_t *thr)
 {
 	struct push * P;
-	pthread_t thr;
 	int rc;
 
 	/* Allocate structure. */
@@ -85,7 +84,7 @@ pushbits(int in, int out)
 	P->out = out;
 
 	/* Create thread. */
-	if ((rc = pthread_create(&thr, NULL, workthread, P)) != 0) {
+	if ((rc = pthread_create(thr, NULL, workthread, P)) != 0) {
 		warn0("pthread_create: %s", strerror(rc));
 		goto err1;
 	}

--- a/spipe/pushbits.h
+++ b/spipe/pushbits.h
@@ -5,6 +5,6 @@
  * pushbits(in, out):
  * Create a thread which copies data from ${in} to ${out}.
  */
-int pushbits(int, int);
+int pushbits(int, int, pthread_t *);
 
 #endif /* !_PUSHBITS_H_ */


### PR DESCRIPTION
Hi,

Thanks for writing and maintaining spiped!

What do you think about this patch that makes spipe wait for the threads that it has spawned to actually finish their I/O before exiting after the remote socket has been closed?  As things are now, it is possible that the socket will be closed very soon after spipe has passed the data on its internal pipe to one of the pushbits threadsa, but the thread has not yet had a chance to output it.  For a more detailed explanation of an actual failed test case, take a look at http://devel.ringlet.net/security/spiped/pthread-race/

Thanks again for you're doing for spiped, tarsnap, FreeBSD, etc, and keep up the great work!

G'luck,
Peter
