### PR TITLE
pass negative (sets default/max) listen() backlog

### DIFF
--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -327,7 +327,7 @@ sock_listener(const struct sock_addr * sa)
 	}
 
 	/* Mark the socket as listening. */
-	if (listen(s, 10)) {
+	if (listen(s, -1)) {
 		warnp("Error marking socket as listening");
 		goto err1;
 	}


### PR DESCRIPTION
tested on freebsd 10, but it seems to be common (best?) practice on linux too.