### PR TITLE
build: add target for cpusupport-config.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,17 @@ PROGS=		spiped spipe
 BINDIR_DEFAULT=	/usr/local/bin
 CFLAGS_DEFAULT=	-O2
 
-all:
+all: cpusupport-config.h
 	export CFLAGS="$${CFLAGS:-${CFLAGS_DEFAULT}}";	\
 	export LDADD_POSIX=`export CC="${CC}"; cd libcperciva/POSIX && command -p sh posix-l.sh`;	\
 	export CFLAGS_POSIX=`export CC="${CC}"; cd libcperciva/POSIX && command -p sh posix-cflags.sh`;	\
-	( export CC="${CC}"; command -p sh libcperciva/cpusupport/Build/cpusupport.sh ) > cpusupport-config.h;	\
 	. ./cpusupport-config.h;			\
 	for D in ${PROGS}; do				\
 		( cd $${D} && ${MAKE} all ) || exit 2;	\
 	done
+
+cpusupport-config.h:
+	( export CC="${CC}"; command -p sh libcperciva/cpusupport/Build/cpusupport.sh ) > cpusupport-config.h
 
 install: all
 	export BINDIR=$${BINDIR:-${BINDIR_DEFAULT}};	\


### PR DESCRIPTION
Without this, we were recompiling the binaries every time we ran "make"
because cpusupport-config.h was being regenerated, and cpusupport-config.h is
now listed as an explicit dependency for cpusupport_x86_aesni.o.