### PR TITLE
Remove dubious and dead code in proto_conn.c

### DIFF
--- a/proto/proto_conn.c
+++ b/proto/proto_conn.c
@@ -291,12 +291,6 @@ callback_connect_done(void * cookie, int t)
 			goto err1;
 	}
 
-	/* If we have connections and keys, start shuttling data. */
-	if ((C->t != -1) && (C->k_f != NULL) && (C->k_r != NULL)) {
-		if (launchpipes(C))
-			goto err1;
-	}
-
 	/* Success! */
 	return (0);
 


### PR DESCRIPTION
This code is dubious and useless for several reasons:

1. The `(C->t != -1)` condition is useless, as the function already
   would have returned in line 286, if `C->t` was `-1`. Thus this
   part always is `true`.
2. It is not possible for `k_f` and `k_r` to be non-NULL at this place:
   The only place where these struct members are written to is inside
   `proto_conn_create` and `callback_handshake_done`. In the former
   function they always are initialized to NULL, thus the only place
   where a non-NULL value can be written into these struct members is
   inside `callback_handshake_done`. But at that place
   `callback_connect_done` must have returned already (because there is
   no way to perform a handshake, without a connection).