### PR TITLE
travis-CI: osx image already includes openssl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi'
 - 'if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y nmap; fi'
 - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi'
-- 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install nmap openssl; fi'
+- 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install nmap; fi'
 - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CFLAGS="-I/usr/local/opt/openssl/include $CFLAGS" LDFLAGS="-L/usr/local/opt/openssl/lib $LDFLAGS"; fi'
 - 'if [[ "$TRAVIS_OS_NAME" == "osx" && "$CC" == "gcc" ]]; then CC=gcc-4.9; $CC --version; fi'
 script:


### PR DESCRIPTION
We still need the explicit CFLAGS and LDFLAGS, but we don't need to
brew install openssl.