### PR TITLE
build: fix "if ... NOINST" line

### DIFF
--- a/Makefile.BSD
+++ b/Makefile.BSD
@@ -15,7 +15,7 @@ ${D}/Makefile::
 	( cd ${D} && printf 'SRCS=' && ${MAKE} -V SRCS | sed -e 's| cpusupport-config.h||' ) >> $@
 	( cd ${D} && printf 'IDIRS=' && ${MAKE} -V IDIRS ) >> $@
 	( cd ${D} && printf 'LDADD_REQ=' && ${MAKE} -V LDADD_REQ ) >> $@
-	if [ `cd ${D} && ${MAKE} -V NOINST` -eq "1" ]; then	\
+	if [ `cd ${D} && ${MAKE} -V NOINST` ]; then		\
 		cat Makefile.prog |				\
 		    perl -0pe 's/(install:.*?)\n\n//s' >> $@ ;	\
 	else							\


### PR DESCRIPTION
The earlier line worked by coincidence: when there was no NOINST, it would display the error:

    /bin/sh: 1: [: -eq: unexpected operator

and then take the "else" command.  The end result was the Makefiles that we desired, but we didn't receive the result in an appealing manner.