### PR TITLE
libcperciva: put CPU macros inside relevant #ifdef

### DIFF
--- a/libcperciva/cpusupport/cpusupport_x86_aesni.c
+++ b/libcperciva/cpusupport/cpusupport_x86_aesni.c
@@ -2,9 +2,9 @@
 
 #ifdef CPUSUPPORT_X86_CPUID
 #include <cpuid.h>
-#endif
 
 #define CPUID_AESNI_BIT (1 << 25)
+#endif
 
 CPUSUPPORT_FEATURE_DECL(x86, aesni)
 {


### PR DESCRIPTION
This macro is only used in code that hidden by the same #ifdef.
