### PR TITLE
Avoid obscure English grammar

### DIFF
--- a/libcperciva/network/network.h
+++ b/libcperciva/network/network.h
@@ -77,7 +77,7 @@ void network_read_cancel(void *);
  * network_write(fd, buf, buflen, minwrite, callback, cookie):
  * Asynchronously write up to ${buflen} bytes of data from ${buf} to ${fd}.
  * When at least ${minwrite} bytes have been written or on error, invoke
- * ${callback}(${cookie}, lenwrit), where lenwrit is -1 on error and the
+ * ${callback}(${cookie}, lenwritten), where lenwritten is -1 on error and the
  * number of bytes written (between ${minwrite} and ${buflen} inclusive)
  * otherwise.  Return a cookie which can be passed to network_write_cancel in
  * order to cancel the write.

--- a/libcperciva/network/network_write.c
+++ b/libcperciva/network/network_write.c
@@ -133,7 +133,7 @@ failed:
  * network_write(fd, buf, buflen, minwrite, callback, cookie):
  * Asynchronously write up to ${buflen} bytes of data from ${buf} to ${fd}.
  * When at least ${minwrite} bytes have been written or on error, invoke
- * ${callback}(${cookie}, lenwrit), where lenwrit is -1 on error and the
+ * ${callback}(${cookie}, lenwritten), where lenwritten is -1 on error and the
  * number of bytes written (between ${minwrite} and ${buflen} inclusive)
  * otherwise.  Return a cookie which can be passed to network_write_cancel in
  * order to cancel the write.


### PR DESCRIPTION
Yes, people who did a degree in Britain will know that "writ" is the archaic past participle of "write".  But y'know what?  Even you didn't use "writ" consistently!:

    ${callback}(${cookie}, lenwrit), where lenwrit is -1 on
    error and the number of bytes written... otherwise.
                                      ~~~

Let's standardize on "written", and thus use "lenwritten".