### PR TITLE
tests/nc-client: clarify client network errors, block on socket close

### DIFF
--- a/tests/01-connection-open-close-single.sh
+++ b/tests/01-connection-open-close-single.sh
@@ -13,11 +13,12 @@
 scenario_cmd() {
 	# Set up infrastructure.
 	setup_spiped_decryption_server
+	setup_spiped_encryption_server
 
 	# Open and close a connection.
 	setup_check_variables
 	(
-		echo "" | ${nc_client_binary} [127.0.0.1]:${mid_port}
+		echo "" | ${nc_client_binary} [127.0.0.1]:${src_port}
 		echo $? > ${c_exitfile}
 	)
 

--- a/tests/02-connection-open-timeout-single.sh
+++ b/tests/02-connection-open-timeout-single.sh
@@ -14,12 +14,13 @@
 scenario_cmd() {
 	# Set up infrastructure.
 	setup_spiped_decryption_server
+	setup_spiped_encryption_server
 
 	# Open and close a connection, keeping it open for 2 seconds.
 	setup_check_variables
 	(
 		( echo "" ; sleep 2 ) |		\
-			 ${nc_client_binary} [127.0.0.1]:${mid_port}
+			 ${nc_client_binary} [127.0.0.1]:${src_port}
 		echo $? > ${c_exitfile}
 	) &
 	sleep 3

--- a/tests/nc-client/main.c
+++ b/tests/nc-client/main.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -64,10 +65,13 @@ callback_wrote(void * cookie, ssize_t lenwrit)
 	/* We are no longer writing. */
 	send->write_cookie = NULL;
 
-	/* Check that we wrote all our data. */
-	if (lenwrit != send->nchars) {
-		warn0("Mismatch between data sent and data requested to send");
+	/* Check results. */
+	if (lenwrit == -1) {
+		warnp("network_write send");
 		goto err0;
+	} else {
+		/* We should have sent everything. */
+		assert(lenwrit == send->nchars);
 	}
 
 	/* Clear the buffer that was used. */


### PR DESCRIPTION
Yes, given the specific values inside this file's send_input() function,
we're not expecting to see a lenwrit which is neither -1 nor send->nchars.
However, I think the code is more clear this way, and it's not unlikely that
I'll end up copying bits of this file the next time I want to send data over a
network.  Also, if we did somehow see an unexpected value for lenwrit, I think
it would be nice to have a specific error message for that case.