### PR TITLE
libcperciva getopt: silence scan-build warnings

### DIFF
--- a/libcperciva/util/getopt.h
+++ b/libcperciva/util/getopt.h
@@ -1,6 +1,7 @@
 #ifndef _GETOPT_H_
 #define _GETOPT_H_
 
+#include <assert.h>
 #include <setjmp.h>
 #include <stddef.h>
 
@@ -107,8 +108,10 @@ extern int optind, opterr, optreset;
 #define _GETOPT_OPTARG(os, ln)	__GETOPT_OPTARG(os, ln)
 #define __GETOPT_OPTARG(os, ln)						\
 	case ln:							\
-		if (getopt_initialized)					\
+		if (getopt_initialized) {				\
+			assert(optarg != NULL);				\
 			goto getopt_skip_ ## ln;			\
+		}							\
 		getopt_register_opt(os, ln - getopt_ln_min, 1);		\
 		DO_LONGJMP;						\
 	getopt_skip_ ## ln


### PR DESCRIPTION
Previously, scan-build in clang would produce warnings in the form:

```
main.c:159:17: warning: Null pointer passed as an argument to a 'nonnull' parameter
                        if ((opt_p = strdup(optarg)) == NULL)
```

This is not a particularly deterministic bug; creating the obvious minimal
example fails to reproduce this warning.  It seems to require some additional
code to trigger this warning, and a minimal reproduction in one version of
clang can fail to show this problem in a later version of clang.