### PR TITLE
libcperciva poll: explicit cast to (nfds_t)nfds

### DIFF
--- a/libcperciva/events/events_network.c
+++ b/libcperciva/events/events_network.c
@@ -374,7 +374,7 @@ events_network_select(struct timeval * tv)
 	events_network_selectstats_select();
 
 	/* Poll. */
-	while (poll(fds, nfds, timeout) == -1) {
+	while (poll(fds, (nfds_t)nfds, timeout) == -1) {
 		/* EINTR is harmless. */
 		if (errno == EINTR)
 			continue;


### PR DESCRIPTION
On MacOS X, nfds_t is (unsigned int) rather than (unsigned long).

This cast is safe because the only place in which we increase nfds is in
growpollfd(), and we do so in response to adding a new (int)fd to the pollfd
array, and thus therefore nfds won't exceed INT_MAX.