### PR TITLE
Don't allow multiple -o or -r options

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -48,6 +48,7 @@ main(int argc, char * argv[])
 	int opt_g = 0;
 	int opt_j = 0;
 	const char * opt_k = NULL;
+	int opt_o_set = 0;
 	double opt_o = 0.0;
 	const char * opt_t = NULL;
 
@@ -85,8 +86,9 @@ main(int argc, char * argv[])
 			opt_k = optarg;
 			break;
 		GETOPT_OPTARG("-o"):
-			if (opt_o != 0.0)
+			if (opt_o_set)
 				usage();
+			opt_o_set = 1;
 			if (PARSENUM(&opt_o, optarg, 0, INFINITY)) {
 				warn0("Invalid option: -o %s", optarg);
 				exit(1);

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -72,8 +72,10 @@ main(int argc, char * argv[])
 	int opt_j = 0;
 	const char * opt_k = NULL;
 	intmax_t opt_n = 0;
+	int opt_o_set = 0;
 	double opt_o = 0.0;
 	char * opt_p = NULL;
+	int opt_r_set = 0;
 	double opt_r = 0.0;
 	int opt_R = 0;
 	const char * opt_s = NULL;
@@ -143,8 +145,9 @@ main(int argc, char * argv[])
 			}
 			break;
 		GETOPT_OPTARG("-o"):
-			if (opt_o != 0.0)
+			if (opt_o_set)
 				usage();
+			opt_o_set = 1;
 			if (PARSENUM(&opt_o, optarg, 0, INFINITY)) {
 				warn0("Invalid option: -o %s", optarg);
 				exit(1);
@@ -157,8 +160,9 @@ main(int argc, char * argv[])
 				OPT_EPARSE(ch, optarg);
 			break;
 		GETOPT_OPTARG("-r"):
-			if (opt_r != 0.0)
+			if (opt_r_set)
 				usage();
+			opt_r_set = 1;
 			if (PARSENUM(&opt_r, optarg, 0, INFINITY)) {
 				warn0("Invalid option: -r %s", optarg);
 				exit(1);


### PR DESCRIPTION
This does not alter the -n option, as that will happen in a separate PR
(wherein -n 0 will gain semantic meaning).