### PR TITLE
Set MAN= in tests/Makefile.inc

### DIFF
--- a/tests/Makefile.inc
+++ b/tests/Makefile.inc
@@ -1,1 +1,2 @@
+MAN=
 .include "../Makefile.inc"


### PR DESCRIPTION
The test code doesn't have man pages; on recent FreeBSD setting MAN=
is necessary in order to avoid having MAN1 autofilled.