### PR TITLE
gitignore: tests-output/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/nc-server/*.o
 tests/nc-server/nc-server
 tests/valgrind/*.o
 tests/valgrind/potential-memleaks
+tests-output/


### PR DESCRIPTION
The valgrind tests aren't ready (and thus aren't in git master), so I haven't
added tests-valgrind/ to gitignore.