### PR TITLE
tests: use POSIX arguments with ps(1)

### DIFF
--- a/tests/shared_test_functions.sh
+++ b/tests/shared_test_functions.sh
@@ -95,7 +95,7 @@ find_system() {
 # Look for ${cmd} in ps; return 0 if ${cmd} exists.
 has_pid() {
 	cmd=$1
-	pid=`ps -Aopid,command | grep "${cmd}" | grep -v "grep"` || true
+	pid=`ps -Aopid,args | grep "${cmd}" | grep -v "grep"` || true
 	if [ -n "${pid}" ]; then
 		return 0
 	fi


### PR DESCRIPTION
Using "-opid,cmd" worked on Debian/Ubuntu, but complains on Alpine busybox.  In
addition, it acts (almost*) the same as "-opid" on FreeBSD and OpenBSD.

* it does complain "ps: cmd: keyword not found", but this message occurs
at the beginning of the listing, so it's not visible on the screen when testing
with "ps -Aopid,cmd".