### PR TITLE
Properly quote shell strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ CFLAGS_DEFAULT=	-O2
 
 all: cpusupport-config.h
 	export CFLAGS="$${CFLAGS:-${CFLAGS_DEFAULT}}";	\
-	export LDADD_POSIX=`export CC="${CC}"; cd libcperciva/POSIX && command -p sh posix-l.sh "$$PATH"`;	\
-	export CFLAGS_POSIX=`export CC="${CC}"; cd libcperciva/POSIX && command -p sh posix-cflags.sh "$$PATH"`;	\
+	export "LDADD_POSIX=`export CC=\"${CC}\"; cd libcperciva/POSIX && command -p sh posix-l.sh \"$$PATH\"`";	\
+	export "CFLAGS_POSIX=`export CC=\"${CC}\"; cd libcperciva/POSIX && command -p sh posix-cflags.sh \"$$PATH\"`";	\
 	. ./cpusupport-config.h;			\
 	for D in ${PROGS} ${TESTS}; do			\
 		( cd $${D} && ${MAKE} all ) || exit 2;	\


### PR DESCRIPTION
POSIX says that command expansion (e.g., via backticks) takes place
before field splitting; as such,
	export FOO=`echo foo bar`
should have the same effect as
	export FOO=foo bar
i.e., to set FOO=foo and then add the variables FOO and bar (which
will be set to "" if not otherwise initialized) to the environment.

Oddly enough, both bash and FreeBSD's sh get this wrong, and act as
if there are quotes around "FOO=`echo foo bar`".

In the case where the posix-l.sh or posix-cflags.sh shell scripts
emitted multiple options, this resulted in the intended behaviour
being accidentally provided by bash and FreeBSD's sh, while the code
breaks (as it should) in dash (which is POSIX-compliant here).

This commit adds the missing quotes, to ensure that POSIX-compliant
shells give us the intended behaviour.