### PR TITLE
Avoid SIGSEGV on shutdown with target re-resolution

### DIFF
--- a/spiped/main.c
+++ b/spiped/main.c
@@ -315,6 +315,9 @@ main(int argc, char * argv[])
 		goto err5;
 	}
 
+	/* dispatch is now maintaining sas_t. */
+	sas_t = NULL;
+
 	/* Register a handler for SIGTERM. */
 	if (graceful_shutdown_initialize(&callback_graceful_shutdown,
 	    dispatch_cookie)) {
@@ -341,7 +344,6 @@ main(int argc, char * argv[])
 	free(K);
 
 	/* Free arrays of resolved addresses. */
-	sock_addr_freelist(sas_t);
 	sock_addr_freelist(sas_s);
 
 	/* Free pid filename. */


### PR DESCRIPTION
spiped will segfault on shutdown if target address re-resolution is in
use. This is due to two cases of accessing memory that will be freed by
other parts of the code on the first re-resolution cycle. To avoid this:

The DNS timer has to be marked as expired so it's not freed on shutdown
if already expired. Incidentally, the new instance's is recorded so it
can be cancelled on shutdown if not already expired.

Also, the initial target address list as taken from the command line has
to be marked as under dispatch's purview after dispatch_accept() has
been called.