### PR TITLE
Don't use events_shutdown()

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -213,7 +213,6 @@ main(int argc, char * argv[])
 	}
 
 	/* Clean up. */
-	events_shutdown();
 	free(K);
 
 	/* Handle a connection error. */
@@ -226,7 +225,6 @@ main(int argc, char * argv[])
 err3:
 	proto_conn_drop(conn_cookie, PROTO_CONN_CANCELLED);
 	sas_t = NULL;
-	events_shutdown();
 err2:
 	free(K);
 err1:

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -320,7 +320,7 @@ main(int argc, char * argv[])
 	    sas_t, opt_d, opt_f, opt_g, opt_j, K, opt_n, opt_o,
 	    &conndone)) == NULL) {
 		warnp("Failed to initialize connection acceptor");
-		goto err5;
+		goto err4;
 	}
 
 	/* dispatch is now maintaining sas_t. */
@@ -330,7 +330,7 @@ main(int argc, char * argv[])
 	if (graceful_shutdown_initialize(&callback_graceful_shutdown,
 	    dispatch_cookie)) {
 		warn0("Failed to start graceful_shutdown timer");
-		goto err6;
+		goto err5;
 	}
 
 	/*
@@ -339,14 +339,11 @@ main(int argc, char * argv[])
 	 */
 	if (events_spin(&conndone)) {
 		warnp("Error running event loop");
-		goto err6;
+		goto err5;
 	}
 
 	/* Stop accepting connections and shut down the dispatcher. */
 	dispatch_shutdown(dispatch_cookie);
-
-	/* Shut down the events system. */
-	events_shutdown();
 
 	/* Free the protocol secret structure. */
 	free(K);
@@ -360,10 +357,8 @@ main(int argc, char * argv[])
 	/* Success! */
 	exit(0);
 
-err6:
-	dispatch_shutdown(dispatch_cookie);
 err5:
-	events_shutdown();
+	dispatch_shutdown(dispatch_cookie);
 err4:
 	free(K);
 err3:

--- a/tests/dnsthread-resolve/main.c
+++ b/tests/dnsthread-resolve/main.c
@@ -79,9 +79,6 @@ main(int argc, char ** argv)
 		goto err0;
 	}
 
-	/* Clean up. */
-	events_shutdown();
-
 	/* Success! */
 	exit(0);
 

--- a/tests/nc-client/main.c
+++ b/tests/nc-client/main.c
@@ -211,7 +211,6 @@ main(int argc, char ** argv)
 	}
 
 	/* Clean up. */
-	events_shutdown();
 	sock_addr_freelist(sas_t);
 	free(send->buffer);
 
@@ -225,7 +224,6 @@ err3:
 		network_write_cancel(send->write_cookie);
 	if (send->read_cookie != NULL)
 		network_read_cancel(send->read_cookie);
-	events_shutdown();
 err2:
 	sock_addr_freelist(sas_t);
 err1:


### PR DESCRIPTION
Events clean-up is done via atexit and the function was deprecated in
b164ec07fb7015de5c33cfa2c4bd9e835a88c5f2.