### PR TITLE
spipe/main.c: Fix spiped thread stuck on read() operation when remote…

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -288,10 +288,14 @@ main(int argc, char * argv[])
 
 	/* Wait for threads to finish (if necessary) */
 	if (ET.stopped == 0) {
+		if ((rc = pthread_cancel(ET.threads[0])) != 0)
+			warn0("pthread_cancel: %s", strerror(rc));
 		if ((rc = pthread_join(ET.threads[0], NULL)) != 0) {
 			warn0("pthread_join: %s", strerror(rc));
 			goto err2;
 		}
+		if ((rc = pthread_cancel(ET.threads[1])) != 0)
+			warn0("pthread_cancel: %s", strerror(rc));
 		if ((rc = pthread_join(ET.threads[1], NULL)) != 0) {
 			warn0("pthread_join: %s", strerror(rc));
 			goto err2;


### PR DESCRIPTION
Hello, we are seeing the following issue during spipe client cleanup.

When the spiped server connection is terminated, the client can be blocked on a read() operation.
Steps to reproduce:
1. Start spiped daemon
```
[root@my BUILD]# ./spiped -d -s [0.0.0.0]:1234 -t [127.0.0.1]:22 -k ./keyfile -p spiped.pid -F
```
2. Start spipe client
```
[root@my BUILD]# ./spipe -t 127.0.0.1:1234 -k ./keyfile
SSH-2.0-OpenSSH_7.4
```
3. Teminate spiped daemon
```
[root@my BUILD]# ./spiped -d -s [0.0.0.0]:1234 -t [127.0.0.1]:22 -k ./keyfile -p spiped.pid -F
^C
[root@my BUILD]#
```
4. Spipe client does not exit
```
[root@my BUILD]# ./spipe -t 127.0.0.1:1234 -k ./keyfile
SSH-2.0-OpenSSH_7.4

```

The expected behavior is that the spipe client exits when the connection is lost

Attaching gdb to the spipe process reveals that it is blocked on a read operation
```
(gdb) continue
Continuing.
[Thread 0x7fbea5324700 (LWP 2441) exited]
^C
Thread 1 "spipe-1.6.1" received signal SIGINT, Interrupt.
0x00007fbea5cf970a in pthread_join () from /lib64/libpthread.so.0
(gdb) info threads
  Id   Target Id         Frame
* 1    Thread 0x7fbea657a640 (LWP 2440) "spipe-1.6.1" 0x00007fbea5cf970a in pthread_join () from /lib64/libpthread.so.0
  3    Thread 0x7fbea4b23700 (LWP 2442) "spipe-1.6.1" 0x00007fbea5d014f3 in read () from /lib64/libpthread.so.0
(gdb) bt
#0  0x00007fbea5cf970a in pthread_join () from /lib64/libpthread.so.0
#1  0x00000000004025d7 in ?? ()
#2  0x00007fbea575f0ba in __libc_start_main () from /lib64/libc.so.6
#3  0x000000000040265a in ?? ()
(gdb) thread 3
[Switching to thread 3 (Thread 0x7fbea4b23700 (LWP 2442))]
#0  0x00007fbea5d014f3 in read () from /lib64/libpthread.so.0
(gdb) bt
#0  0x00007fbea5d014f3 in read () from /lib64/libpthread.so.0
#1  0x00000000004028d9 in ?? ()
#2  0x00007fbea5cf840b in start_thread () from /lib64/libpthread.so.0
#3  0x00007fbea582b09f in clone () from /lib64/libc.so.6
```
This does not occur, however, is there is data being actively written to the pipe, as this induces a "Bad file descriptor" error from the connection failure and causes the program to exit.

Propose to cancel threads before joining, according to the POSIX spec it should be safe to cancel on read().

Please let me know if you have any feedback on the MR.

Version: 1.6.1 (Also tested on master)
