### PR TITLE
Actions: move from macOS 10.15 to 11

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -67,7 +67,7 @@ jobs:
       run: test -z "$(git status --porcelain=v1)"
   macOS:
     name: macOS
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
GitHub is depreciating macos 10.15.