### PR TITLE
Invoke usage for missing hostnames in -[st]

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -221,7 +221,7 @@ main(int argc, char * argv[])
 		usage();
 	if (!(opt_o > 0.0))
 		usage();
-	if (opt_t == NULL)
+	if ((opt_t == NULL) || (opt_t[0] == ':'))
 		usage();
 
 	/* Initialize the "events & threads" cookie. */

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -239,9 +239,9 @@ main(int argc, char * argv[])
 		usage();
 	if ((opt_r != 60.0) && opt_R)
 		usage();
-	if (opt_s == NULL)
+	if ((opt_s == NULL) || (opt_s[0] == ':'))
 		usage();
-	if (opt_t == NULL)
+	if ((opt_t == NULL) || (opt_t[0] == ':'))
 		usage();
 
 	/*


### PR DESCRIPTION
A source or destination address of the form ":1234" is parsed as a hostname of "" which is guaranteed to never work.  While we can't reject all possible invalid addresses at this point -- and probably shouldn't since the resolver can give more informative errors -- this particular case can easily be produced from a broken shell script (with a hostname variable accidentally not set), so it's more worthy of rejection via usage() than most.

Suggested by:	Ross Richardson