### PR TITLE
Give an error for addresses lacking a hostname

### DIFF
--- a/libcperciva/util/sock.c
+++ b/libcperciva/util/sock.c
@@ -242,6 +242,10 @@ sock_resolve(const char * addr)
 	char * ips;
 	long p;
 
+	/* Check syntax. */
+	if (sock_addr_validate(addr))
+		goto err0;
+
 	/* If the address starts with '/', it's a Unix domain socket. */
 	if (addr[0] == '/') {
 		res = sock_resolve_unix(addr);

--- a/libcperciva/util/sock_util.c
+++ b/libcperciva/util/sock_util.c
@@ -11,6 +11,7 @@
 
 #include "asprintf.h"
 #include "sock.h"
+#include "warnp.h"
 
 #include "sock_internal.h"
 #include "sock_util.h"
@@ -334,4 +335,36 @@ sock_addr_ensure_port(const char * addr)
 err0:
 	/* Failure! */
 	return (NULL);
+}
+
+/**
+ * sock_addr_validate(addr):
+ * Check that ${addr} is syntactically valid, but do not perform any address
+ * resolution.
+ */
+int
+sock_addr_validate(const char * addr)
+{
+
+	/* Sanity check. */
+	assert(addr != NULL);
+
+	/* Check for an empty address. */
+	if (strlen(addr) == 0) {
+		warn0("Empty socket address.");
+		goto err0;
+	}
+
+	/* If this isn't a UNIX socket address, check for a missing hostname. */
+	if ((addr[0] != '/') && (addr[0] == ':')) {
+		warn0("No host in \"%s\"", addr);
+		goto err0;
+	}
+
+	/* Success! */
+	return (0);
+
+err0:
+	/* Failure! */
+	return (-1);
 }

--- a/libcperciva/util/sock_util.h
+++ b/libcperciva/util/sock_util.h
@@ -57,4 +57,11 @@ char * sock_addr_prettyprint(const struct sock_addr *);
  */
 char * sock_addr_ensure_port(const char *);
 
+/**
+ * sock_addr_validate(addr):
+ * Check that ${addr} is syntactically valid, but do not perform any address
+ * resolution.
+ */
+int sock_addr_validate(const char *);
+
 #endif /* !SOCK_UTIL_H_ */

--- a/spipe/main.c
+++ b/spipe/main.c
@@ -13,6 +13,7 @@
 #include "graceful_shutdown.h"
 #include "parsenum.h"
 #include "sock.h"
+#include "sock_util.h"
 #include "warnp.h"
 
 #include "proto_conn.h"
@@ -221,7 +222,9 @@ main(int argc, char * argv[])
 		usage();
 	if (!(opt_o > 0.0))
 		usage();
-	if (opt_t == NULL)
+	if ((opt_t == NULL) || sock_addr_validate(opt_t))
+		usage();
+	if (opt_b && sock_addr_validate(opt_b))
 		usage();
 
 	/* Initialize the "events & threads" cookie. */

--- a/spiped/main.c
+++ b/spiped/main.c
@@ -13,6 +13,7 @@
 #include "parsenum.h"
 #include "setuidgid.h"
 #include "sock.h"
+#include "sock_util.h"
 #include "warnp.h"
 
 #include "dispatch.h"
@@ -239,9 +240,11 @@ main(int argc, char * argv[])
 		usage();
 	if ((opt_r != 60.0) && opt_R)
 		usage();
-	if (opt_s == NULL)
+	if ((opt_s == NULL) || sock_addr_validate(opt_s))
 		usage();
-	if (opt_t == NULL)
+	if ((opt_t == NULL) || sock_addr_validate(opt_t))
+		usage();
+	if (opt_b && sock_addr_validate(opt_b))
 		usage();
 
 	/*


### PR DESCRIPTION
A source or destination address of the form ":1234" is parsed as a hostname of "" which is guaranteed to never work.  While we don't want to give special error messages for all possible invalid addresses, this particular case can easily be produced from a broken shell script (with a hostname variable accidentally not set), so it's worth having a special error message.

Suggested by:	Ross Richardson