### PR TITLE
Fix bug #734

### DIFF
--- a/spipe/main.c
+++ b/spipe/main.c
@@ -299,7 +299,7 @@ main(int argc, char * argv[])
 	/* Loop until we're done with the connection. */
 	if (events_spin(&ET.conndone)) {
 		warnp("Error running event loop");
-		goto err5;
+		goto err7;
 	}
 
 	/* Wait for threads to finish (if necessary) */


### PR DESCRIPTION
This PR fixes a race condition:

- spipe/main.c: cancel threads on events_spin() failure (Fixes Tarsnap/tarsnap#734)