### PR TITLE
proto_crypt: clear the remaining stack buffers

### DIFF
--- a/lib/proto/proto_crypt.c
+++ b/lib/proto/proto_crypt.c
@@ -113,6 +113,9 @@ proto_crypt_secret(const char * filename)
 	/* Compute the final hash and wipe context state. */
 	SHA256_Final(K->K, &ctx);
 
+	/* Clear sensitive material from the stack. */
+	insecure_memzero(buf, sizeof(buf));
+
 	/* Success! */
 	return (K);
 
@@ -123,6 +126,9 @@ err2:
 
 	/* Wipe context state. */
 	SHA256_Final(K->K, &ctx);
+
+	/* Clear sensitive material from the stack. */
+	insecure_memzero(buf, sizeof(buf));
 err1:
 	proto_crypt_secret_free(K);
 err0:
@@ -166,6 +172,9 @@ proto_crypt_dhmac(const struct proto_secret * K,
 	/* Copy out diffie-hellman parameter MAC keys (in the right order). */
 	memcpy(dhmac_c, &dk_1[0], PCRYPT_DHMAC_LEN);
 	memcpy(dhmac_s, &dk_1[PCRYPT_DHMAC_LEN], PCRYPT_DHMAC_LEN);
+
+	/* Clear sensitive material from the stack. */
+	insecure_memzero(dk_1, sizeof(dk_1));
 }
 
 /**


### PR DESCRIPTION
> **Disclosure, per this repository's `AGENTS.md`:** I am an LLM (Claude), submitting on behalf of the account owner. I am available to discuss this change and to revise it in response to review feedback.

Fixes #436.

#426 wiped `dk_2` and `nonce_y` in `proto_crypt_mkkeys()`.  Two buffers holding
key material in the same file were not covered by it:

* `proto_crypt_secret()` reads the key file into `buf[BUFSIZ]` and never zeroes
  it, on either the success path or the read-error path at `err2`.  That buffer
  is the pre-image of the shared secret — the whole key file, for a key file of
  `BUFSIZ` bytes or less.  The function already wipes the SHA-256 context two
  lines above, and `proto_crypt_secret_free()` zeroes the derived secret; the
  buffer it was derived from was the gap.  Both `spiped` and `spipe` call this
  once at startup and then run for the lifetime of the process.
* `proto_crypt_dhmac()` leaves `dk_1`, the derived diffie-hellman MAC keys, in
  the frame when it returns.  Called once per connection.

Three `insecure_memzero()` calls, using the idiom from #426.

### Deliberately not covered

* `ctx` in `proto_crypt_enc()` and `proto_crypt_dec()` — it is a copy of
  `k->ctx_init`, which stays in the key structure for the whole connection, so
  wiping the copy buys nothing; and both functions run once per 1024-byte
  packet, which is not somewhere to add work for no gain.
* `nonce_CS` in `proto_crypt_dhmac()` — the nonces are sent over the wire in
  the clear.

Happy to add either if you would rather have the file uniformly wiped.

### Testing

No behaviour change: the writes happen after the last read of each buffer in
every path, and neither buffer is read again.  `insecure_memzero.h` is already
included by this file.
