### PR TITLE
dnsthread: register the wakeup listener before starting work

### DIFF
--- a/lib/dnsthread/dnsthread.c
+++ b/lib/dnsthread/dnsthread.c
@@ -265,20 +265,25 @@ dnsthread_resolveone(DNSTHREAD T, const char * addr,
 	T->callback = callback;
 	T->cookie = cookie;
 
+	/*
+	 * We want a callback when the worker thread pokes us.  Register this
+	 * before handing the work over: once the thread is running we cannot
+	 * take the work back, and without this registration nothing would
+	 * ever read the completion byte or free the results.
+	 */
+	if (events_network_register(callback_resolveone, T, T->wakeupsock[1],
+	    EVENTS_NETWORK_OP_READ)) {
+		warnp("Error registering wakeup listener");
+		goto err2;
+	}
+
 	/* There is now work for the thread to do. */
 	T->state = THREAD_HASWORK;
 
 	/* Wake up the worker thread. */
 	if ((rc = pthread_cond_signal(&T->cv)) != 0) {
 		warn0("pthread_cond_signal: %s", strerror(rc));
-		goto err1;
-	}
-
-	/* We want a callback when the worker thread pokes us. */
-	if (events_network_register(callback_resolveone, T, T->wakeupsock[1],
-	    EVENTS_NETWORK_OP_READ)) {
-		warnp("Error registering wakeup listener");
-		goto err1;
+		goto err3;
 	}
 
 ealready:
@@ -295,6 +300,11 @@ ealready:
 	/* Success! */
 	return (0);
 
+err3:
+	T->state = THREAD_SLEEPING;
+	events_network_cancel(T->wakeupsock[1], EVENTS_NETWORK_OP_READ);
+err2:
+	free(T->addr);
 err1:
 	pthread_mutex_unlock(&T->mtx);
 err0:


### PR DESCRIPTION
> **Disclosure, per this repository's `AGENTS.md`:** I am an LLM (Claude), submitting on behalf of the account owner. I am available to discuss this change and to revise it in response to review feedback.

Fixes #438.

`dnsthread_resolveone()` set `THREAD_HASWORK` and signalled the worker thread
*before* registering the wakeup listener, and `err1` only unlocked the mutex.
A failed `events_network_register()` therefore returned -1 with a resolution
already running and nothing registered to read its completion byte: `T->addr`
and `T->sas` both leaked, the caller's callback never fired, and the
undrained byte made the next `dnsthread_resolveone()` fire
`callback_resolveone()` immediately — freeing `T->addr` while the worker
thread was passing that same pointer to `sock_resolve()`.

### The change

Register the listener before handing the work over, and unwind properly:

* `err2` frees the strduped address — reached when the registration fails,
  at which point the worker has not been touched.
* `err3` additionally restores `THREAD_SLEEPING` and cancels the
  registration — reached only if `pthread_cond_signal()` fails.
* `err1` is unchanged and still handles the `strdup()` failure, where there is
  nothing to free.

`events_network_cancel()`'s return is ignored, matching `network_accept.c`,
`network_connect.c`, `network_read.c` and `network_write.c`.

### Note

I did not try to make the failure path take the work *back* from the worker
once it is running, because it cannot be done safely — the worker drops the
mutex for the duration of `sock_resolve()`.  Doing the registration first
means that situation never arises.
