### PR TITLE
proto_handshake: clear the cookie before freeing it

### DIFF
--- a/lib/proto/proto_handshake.c
+++ b/lib/proto/proto_handshake.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 
 #include "crypto_entropy.h"
+#include "insecure_memzero.h"
 #include "network.h"
 
 #include "proto_crypt.h"
@@ -53,7 +54,8 @@ handshakefail(struct handshake_cookie * H)
 	/* Perform the callback. */
 	rc = (H->callback)(H->cookie, NULL, NULL);
 
-	/* Free the cookie. */
+	/* Clear sensitive material and free the cookie. */
+	insecure_memzero(H, sizeof(struct handshake_cookie));
 	free(H);
 
 	/* Return status from callback. */
@@ -112,6 +114,7 @@ proto_handshake(int s, int decr, int nopfs, int requirepfs,
 err2:
 	network_write_cancel(H->write_cookie);
 err1:
+	insecure_memzero(H, sizeof(struct handshake_cookie));
 	free(H);
 err0:
 	/* Failure! */
@@ -298,7 +301,8 @@ handshakedone(struct handshake_cookie * H)
 	/* Perform the callback. */
 	rc = (H->callback)(H->cookie, c, s);
 
-	/* Free the cookie. */
+	/* Clear sensitive material and free the cookie. */
+	insecure_memzero(H, sizeof(struct handshake_cookie));
 	free(H);
 
 	/* Return status code from callback. */
@@ -326,6 +330,7 @@ proto_handshake_cancel(void * cookie)
 	if (H->write_cookie != NULL)
 		network_write_cancel(H->write_cookie);
 
-	/* Free the cookie. */
+	/* Clear sensitive material and free the cookie. */
+	insecure_memzero(H, sizeof(struct handshake_cookie));
 	free(H);
 }


### PR DESCRIPTION
> **Disclosure, per this repository's `AGENTS.md`:** I am an LLM (Claude), submitting on behalf of the account owner. I am available to discuss this change and to revise it in response to review feedback.

Fixes #440.

`struct handshake_cookie` holds `x` — the diffie-hellman private value, whose
being forgotten is what makes the PFS handshake forward-secret — and the two
diffie-hellman parameter MAC keys derived from the shared secret.  All four
sites which free the cookie did so without wiping it:

* `handshakefail()`
* `proto_handshake()` at `err1`
* `handshakedone()`, which runs once per successful connection, at exactly the
  point where `x` has served its purpose
* `proto_handshake_cancel()`

Four `insecure_memzero()` calls and the include; no other change.

### Why all four rather than only where `x` is populated

`err1` is reached before the diffie-hellman value is ever generated, so
strictly it has nothing to protect.  I wiped it anyway so that "the cookie is
always cleared before it is freed" is a property that holds without the reader
having to trace which paths populate what — the same reasoning as
`scryptenc.c`, which wipes `dk` at `err1` on paths where it may never have
been filled in.  Happy to drop that one if you would rather keep it exact.

The nonces and `yh_*` values in the cookie go over the wire in the clear, so
they are not the point here; they are simply covered by wiping the whole
structure, which is cheaper and less fragile than picking members.
