### PR TITLE
pthread_create_blocking_np: don't fail after the thread has started

### DIFF
--- a/lib/util/pthread_create_blocking_np.c
+++ b/lib/util/pthread_create_blocking_np.c
@@ -1,6 +1,9 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <string.h>
+
+#include "warnp.h"
 
 #include "pthread_create_blocking_np.h"
 
@@ -78,6 +81,7 @@ pthread_create_blocking_np(pthread_t * restrict thread,
 {
 	struct wrapped_cookie * U;
 	int rc;
+	int rc_cleanup;
 
 	/*
 	 * Allocate our cookie and store parameters.  The C standard does not
@@ -126,15 +130,31 @@ pthread_create_blocking_np(pthread_t * restrict thread,
 		if ((rc = U->rc_sync) != 0)
 			goto err5;
 	}
-	if ((rc = pthread_mutex_unlock(&U->mutex)) != 0)
-		goto err4;
 
-	/* Clean up synchronization-related variables. */
-	if ((rc = pthread_cond_destroy(&U->cond)) != 0)
-		goto err2;
-	if ((rc = pthread_mutex_destroy(&U->mutex)) != 0)
-		goto err1;
+	/*
+	 * The thread is running, so it owns ${arg} and will run
+	 * ${start_routine} to completion.  From here we must report
+	 * success: this function promises that on failure the provided
+	 * routine was not run, and a caller which frees ${arg} after an
+	 * error return would be freeing memory the thread is still using.
+	 *
+	 * Anything which fails below is one of our own synchronization
+	 * variables.  The caller cannot act on that, so warn and carry on.
+	 */
+	if ((rc_cleanup = pthread_mutex_unlock(&U->mutex)) != 0) {
+		warn0("pthread_mutex_unlock: %s", strerror(rc_cleanup));
 
+		/* Do not destroy a mutex which we might still hold. */
+		goto done;
+	}
+	if ((rc_cleanup = pthread_cond_destroy(&U->cond)) != 0) {
+		warn0("pthread_cond_destroy: %s", strerror(rc_cleanup));
+		goto done;
+	}
+	if ((rc_cleanup = pthread_mutex_destroy(&U->mutex)) != 0)
+		warn0("pthread_mutex_destroy: %s", strerror(rc_cleanup));
+
+done:
 	/* Clean up. */
 	free(U);
 
@@ -147,7 +167,6 @@ err5:
 	 * is more important.
 	 */
 	pthread_mutex_unlock(&U->mutex);
-err4:
 	pthread_cancel(*thread);
 	pthread_join(*thread, NULL);
 err3:


### PR DESCRIPTION
Fixes #442.

`pthread_create_blocking_np()` had three failure returns that fire *after* the created thread has set `U->running` and taken ownership of `arg`:

| line | failure | went to | returned |
|---|---|---|---|
| 129 | `pthread_mutex_unlock()` | `err4` — cancel, join | `rc` |
| 133 | `pthread_cond_destroy()` | `err2` | `rc` |
| 135 | `pthread_mutex_destroy()` | `err1` | `rc` |

That contradicts the contract you set out in #327 — *"if we find that pthread functions are breaking, we don't run the provided routine, and `pthread_create_blocking()` returns with an error"* — and `spipe/pushbits.c:102` relies on exactly that contract when it frees `P` at line 111. The `err4` path is a deterministic double free once reached, because cancelling and joining a started thread runs `workthread_cleanup()`, which frees `P` before `pushbits()` frees it again.

## The change

Report success once the thread is running. A failure past that point is in this function's own synchronization variables, which the caller cannot act on, so warn and carry on rather than handing back an error nobody can act on correctly.

Two details worth calling out:

- If the unlock fails, the mutex is not destroyed — destroying a mutex we might still hold would be undefined. That path warns and goes straight to `free(U)`, leaking the pthread objects' internal resources on a path that should not occur.
- `err4:` is removed rather than left in place. It was only reachable by `goto` from line 130, and once that goes the label is unreferenced, which `-Wunused-label` reports under `-Wall`. Its two statements stay where they were, in the `err5` path.

`err5` reached from a failed `pthread_cond_wait()` still cancels and joins. I left that alone deliberately: there the thread's state is genuinely unknown, `U->running` cannot be read safely because the mutex may not be held, and picking a behaviour there is a judgement call rather than a fix. #442 says the same.

## Testing

**I could not build or run this** — I am on Windows with no C toolchain and no WSL, and I was not going to install one to get a build. So this is from reading the control flow, not from a reproduction, and I would rather say so than imply otherwise.

What that means for review: the change is confined to one function, the labels are all still defined and referenced (`err0`-`err3`, `err5`, and the new `done`), the added `warn0()` and `strerror()` need `warnp.h` and `string.h`, both now included, and `lib/util/graceful_shutdown.c` already includes `warnp.h` from the same directory so the include path is fine. The behaviour change is only on paths that currently return an error, so the success path is untouched.

Please do give it a compile before taking it seriously.

---

**LLM disclosure** (`AGENTS.md`, Communication): I am an LLM. This account is monitored and I am available for review rounds -- I can respond to questions and revise the change. If I go quiet for long enough to be a nuisance, please just close it rather than waiting on me.