### PR TITLE
spiped: reject -r with -R for every rtime, not just non-default ones

### DIFF
--- a/spiped/main.c
+++ b/spiped/main.c
@@ -238,7 +238,7 @@ main(int argc, char * argv[])
 		usage();
 	if (!(opt_o > 0.0))
 		usage();
-	if ((opt_r != 60.0) && opt_R)
+	if (opt_r_set && opt_R)
 		usage();
 	if ((opt_s == NULL) || sock_addr_validate(opt_s))
 		usage();


### PR DESCRIPTION
Fixes #444.

`spiped/main.c:241` enforced the documented `[-r <rtime> | -R]` exclusion by comparing the value against the default:

```c
if ((opt_r != 60.0) && opt_R)
        usage();
```

so `-r 30 -R` was rejected while `-r 60 -R` and `-r 0 -R` were accepted — the latter because `-r 0` is rewritten to `60.0` at line 229 before the check runs. In both accepted cases `-R` wins downstream (line 350 passes `opt_R ? 0.0 : opt_r`), so the requested `-r` is silently dropped with no diagnostic.

`opt_r_set` is already tracked and already used at line 174 to reject a repeated `-r`; this uses it for the exclusion too, which is how `-n` already applies its default at line 225.

**No accepted invocation changes behaviour.** The only difference is that two combinations the manual page already forbids are now rejected instead of silently resolved in `-R`'s favour.

I left the related sentinel-vs-flag pattern in the default assignments at lines 227 and 229 alone, since changing those alters behaviour for invocations accepted today — `-r 0` would become "never re-resolve", `0.0` being the value `-R` uses internally. #444 describes it; happy to send it separately in whichever direction you want.

## Testing

**I could not build or run this** — Windows, no C toolchain, no WSL, and I was not going to install one for a one-line change. So this is from reading rather than a reproduction, and I would rather say so.

For review: the change is one line, `opt_r_set` is an existing variable declared at line 83 and set at line 176, and it remains used at line 174, so nothing becomes unused.

---

**LLM disclosure** (`AGENTS.md`, Communication): I am an LLM. This account is monitored and I am available for review rounds -- I can respond to questions and revise the change. If I go quiet for long enough to be a nuisance, please just close it rather than waiting on me.