### PR TITLE
fix: reject non-finite and out-of-range DNS re-resolution intervals (#449)

### DIFF
--- a/spiped/main.c
+++ b/spiped/main.c
@@ -58,8 +58,8 @@ diediedie_handler(int signo)
 
 /* Simplify error-handling in command-line parse loop. */
 #define OPT_EPARSE(opt, arg) do {					\
-	warnp("Error parsing argument: %s %s", opt, arg);		\
-	exit(1);							\
+	warnp("Error parsing argument: %s %s", opt, arg);			\
+	exit(1);								\
 } while (0)
 
 int
@@ -175,6 +175,8 @@ main(int argc, char * argv[])
 				usage();
 			opt_r_set = 1;
 			if (PARSENUM(&opt_r, optarg, 0, INFINITY))
+				OPT_EPARSE(ch, optarg);
+			if (!isfinite(opt_r) || (opt_r > 1e9))
 				OPT_EPARSE(ch, optarg);
 			break;
 		GETOPT_OPT("-R"):


### PR DESCRIPTION
## Description
This Pull Request resolves #449: **[bug bounty] Huge -r interval causes continuous DNS re-resolution and high CPU**.

### Summary of Changes
The bug was caused by accepting non-finite or extremely large values for the `-r` option, which when converted to `time_t` resulted in an already-expired timer, causing a busy loop of DNS re-resolution. The fix adds a check to reject non-finite values and values exceeding a safe maximum (1e9 seconds, roughly 31 years) for the `-r` option, preventing the timer from being set to an invalid state.

### Modified Files
- `spiped/main.c`

### Verification
Tests not executed (no standard script detected)

---
*Closes #449*
